### PR TITLE
Instagram: Missing div props are now added to div

### DIFF
--- a/src/components/embeds/InstagramEmbed.tsx
+++ b/src/components/embeds/InstagramEmbed.tsx
@@ -201,6 +201,7 @@ export const InstagramEmbed = ({
 
   return (
     <div
+      {...divProps}
       className={classNames('rsme-embed rsme-instagram-embed', divProps.className)}
       style={{
         overflow: 'hidden',


### PR DESCRIPTION
Is there any reasoning why the remaining div props were not passed on? If not we can gladly merge my changes. I applied the spread before the manual set attributes so noone can accidentally overwrite them.