### PR TITLE
Upgrade Facebook sdk version to 16.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ lockblocks.log
 
 #Intellij
 .idea
+
+/.project

--- a/src/components/embeds/FacebookEmbed.tsx
+++ b/src/components/embeds/FacebookEmbed.tsx
@@ -7,7 +7,7 @@ import { generateUUID } from '../uuid';
 import { EmbedStyle } from './EmbedStyle';
 import { Subs } from 'react-sub-unsub';
 
-const embedJsScriptSrc = 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2';
+const embedJsScriptSrc = 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v16.0';
 const defaultEmbedWidth = 550;
 const maxPlaceholderWidth = defaultEmbedWidth;
 const defaultPlaceholderHeight = 372;


### PR DESCRIPTION
Fix error:

```
Refused to display 'https://www.facebook.com/' in a frame because it set 'X-Frame-Options' to 'deny'.
```

This error occurs when we are not logged into Facebook.

Fixes #22