### PR TITLE
feat: Re-enable "captioned" prop in InstagramEmbed component

### DIFF
--- a/src/components/embeds/InstagramEmbed.tsx
+++ b/src/components/embeds/InstagramEmbed.tsx
@@ -47,6 +47,7 @@ export const InstagramEmbed = ({
   width,
   height,
   linkText = 'View post on Instagram',
+  captioned = false,
   placeholderImageUrl,
   placeholderSpinner,
   placeholderSpinnerDisabled = false,
@@ -211,7 +212,7 @@ export const InstagramEmbed = ({
         className="instagram-media"
         data-instgrm-permalink={`${cleanUrlWithEndingSlash}?utm_source=ig_embed&utm_campaign=loading`}
         data-instgrm-version={igVersion}
-        data-instgrm-captioned
+        data-instgrm-captioned = {captioned ? captioned : undefined}
         data-width={isPercentageWidth ? '100%' : width ?? undefined}
         style={{
           width: 'calc(100% - 2px)',


### PR DESCRIPTION
This pull request addresses allowing users to determine whether captions should be displayed or not.

Changes made:
I've introduced a new prop, 'captioned,' to the InstagramEmbed component's properties. When this prop is set to true, the "data-instgrm-captioned" attribute will be set to true. Conversely, if the prop is set to false, the attribute will be left undefined

Here's how it operates:
When the 'captioned' prop is set to true, the component operates normally, displaying captions. Conversely, if the 'captioned' prop is set to false, the captions will be hidden. The default behavior is set to false.

I've thoroughly tested this enhancement and achieved excellent results.

Fixes [#46](url)

Best