### PR TITLE
fix: remove Instagram loading line

### DIFF
--- a/src/components/embeds/InstagramEmbed.tsx
+++ b/src/components/embeds/InstagramEmbed.tsx
@@ -213,9 +213,6 @@ export const InstagramEmbed = ({
         data-instgrm-version={igVersion}
         data-instgrm-captioned={captioned ? captioned : undefined}
         data-width={isPercentageWidth ? '100%' : width ?? undefined}
-        style={{
-          width: 'calc(100% - 2px)',
-        }}
       >
         {!placeholderDisabled && placeholder}
         <div id={uuidRef.current} className="instagram-media-pre-embed rsme-d-none">

--- a/src/components/embeds/InstagramEmbed.tsx
+++ b/src/components/embeds/InstagramEmbed.tsx
@@ -203,6 +203,7 @@ export const InstagramEmbed = ({
         height: height ?? undefined,
         borderRadius,
         ...divProps.style,
+        position: 'relative',
       }}
     >
       <EmbedStyle />
@@ -213,6 +214,9 @@ export const InstagramEmbed = ({
         data-instgrm-version={igVersion}
         data-instgrm-captioned={captioned ? captioned : undefined}
         data-width={isPercentageWidth ? '100%' : width ?? undefined}
+        style={{
+          width: 'calc(100% - 2px)',
+        }}
       >
         {!placeholderDisabled && placeholder}
         <div id={uuidRef.current} className="instagram-media-pre-embed rsme-d-none">


### PR DESCRIPTION
Removing the width style seems to fix the Instagram overflow when loading
https://github.com/justinmahar/react-social-media-embed/issues/65

I added this in my current project as a temporary fix:
```css
.instagram-media {
  width: 0 !important;
}
```